### PR TITLE
Replaced RESIGNATION datapackage type with SERVER_ERROR

### DIFF
--- a/app/src/main/java/com/example/jarchess/MatchMakingActivity.java
+++ b/app/src/main/java/com/example/jarchess/MatchMakingActivity.java
@@ -47,6 +47,8 @@ public class MatchMakingActivity extends AppCompatActivity {
 
     @Override
     protected void onStart() {
+        Log.d(TAG, "onStart() called");
+        Log.d(TAG, "onStart is running on thread: " + Thread.currentThread().getName());
         super.onStart();
         matchMakerLauncher.startAction();
     }
@@ -141,7 +143,8 @@ public class MatchMakingActivity extends AppCompatActivity {
         }
 
         public void startAction() {
-
+            Log.d(TAG, "startAction: onlineMatchInfoBundle set to null");
+            onlineMatchInfoBundle = null;
             // start a new thread to launch the online match maker.
             new LoggedThread(TAG, new Runnable() {
                 @Override
@@ -149,7 +152,7 @@ public class MatchMakingActivity extends AppCompatActivity {
                     try {
                         Log.i(TAG, "Creating onlinematchMakerBundle");
                         onlineMatchInfoBundle = OnlineMatchMaker.getInstance().getOnlineMatchInfoBundle();
-                        Log.i(TAG, "Online match info bundle = " + onlineMatchInfoBundle);
+                        Log.i(TAG, "Online match info bundle set to " + onlineMatchInfoBundle);
                         MatchBuilder.getInstance().multiplayerSetup(onlineMatchInfoBundle);
                         Intent intent = new Intent();
                         intent.putExtra("CANCELED", false);

--- a/app/src/main/java/com/example/jarchess/match/MatchNetworkIO.java
+++ b/app/src/main/java/com/example/jarchess/match/MatchNetworkIO.java
@@ -7,6 +7,7 @@ import com.example.jarchess.match.events.MatchEndingEvent;
 import com.example.jarchess.match.events.MatchEndingEventManager;
 import com.example.jarchess.match.participant.RemoteOpponent;
 import com.example.jarchess.match.result.ChessMatchResult;
+import com.example.jarchess.match.result.ServerErrorResult;
 import com.example.jarchess.match.turn.Turn;
 import com.example.jarchess.match.turn.TurnReceiver;
 import com.example.jarchess.match.turn.TurnSender;
@@ -135,7 +136,7 @@ public class MatchNetworkIO {
 
         @Override
         public void send(ChessMatchResult chessMatchResult) {
-            if (chessMatchResult != null) {
+            if (chessMatchResult != null && !(chessMatchResult instanceof ServerErrorResult)) {
                 Log.d(TAG, "send() called with: chessMatchResult = [" + chessMatchResult + "]");
                 Log.d(TAG, "send is running on thread: " + Thread.currentThread().getName());
 
@@ -380,6 +381,11 @@ public class MatchNetworkIO {
                                             lock.notifyAll();
                                         }
                                         break;
+
+                                    case SERVER_ERROR:
+                                        ChessMatchResult result = new ServerErrorResult();
+                                        MatchEndingEvent event = new MatchEndingEvent(result);
+                                        MatchEndingEventManager.getInstance().notifyAllListeners(event);
 
                                     default:
                                         throw new IllegalStateException("Unexpected datapackage type: " + datapackage.getDatapackageType());

--- a/app/src/main/java/com/example/jarchess/match/result/ChessMatchResult.java
+++ b/app/src/main/java/com/example/jarchess/match/result/ChessMatchResult.java
@@ -88,7 +88,7 @@ public abstract class ChessMatchResult implements JSONConvertible<ChessMatchResu
 
             JSONConverter converter = resultType.getJSONConverter();
             Log.d(TAG, "convertFromJSONObject: converter = " + converter);
-            JSONConvertible tmp = converter.convertFromJSONObject(jsonObject); //TODO check this
+            JSONConvertible tmp = converter.convertFromJSONObject(jsonObject);
 
             if (tmp instanceof ChessMatchResult) {
                 return (ChessMatchResult) tmp;

--- a/app/src/main/java/com/example/jarchess/match/result/ResultType.java
+++ b/app/src/main/java/com/example/jarchess/match/result/ResultType.java
@@ -17,7 +17,8 @@ public enum ResultType implements JSONConvertible<ResultType> {
     AGREED_UPON_DRAW(5),
     REPETITION_RULE_DRAW(6),
     STALEMATE_DRAW(7),
-    X_MOVE_RULE_DRAW(8);
+    X_MOVE_RULE_DRAW(8),
+    SERVER_ERROR(9);
 
     private static final JSONConverter[] jsonConverters = new JSONConverter[values().length];
     private static boolean convertersNeedToBeSetUp = true;
@@ -45,6 +46,7 @@ public enum ResultType implements JSONConvertible<ResultType> {
             jsonConverters[REPETITION_RULE_DRAW.intValue] = RepetitionRuleDrawResult.JSON_CONVERTER;
             jsonConverters[STALEMATE_DRAW.intValue] = StalemateDrawResult.JSON_CONVERTER;
             jsonConverters[X_MOVE_RULE_DRAW.intValue] = XMoveRuleDrawResult.JSON_CONVERTER;
+            jsonConverters[SERVER_ERROR.intValue] = ServerErrorResult.JSON_CONVERTER;
         }
         return jsonConverters[intValue];
     }

--- a/app/src/main/java/com/example/jarchess/match/result/ServerErrorResult.java
+++ b/app/src/main/java/com/example/jarchess/match/result/ServerErrorResult.java
@@ -1,0 +1,66 @@
+package com.example.jarchess.match.result;
+
+import androidx.annotation.NonNull;
+
+import com.example.jarchess.online.datapackage.JSONConverter;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import static com.example.jarchess.match.result.ResultType.EXCEPTION;
+import static com.example.jarchess.match.result.ResultType.SERVER_ERROR;
+
+public class ServerErrorResult extends DrawResult {
+    public static final String JSON_PROPERTY_NAME_MSG = "msg";
+    public static final JSONConverter<ChessMatchResult> JSON_CONVERTER = ServerErrorResult.ServerErrorResultJSONConverter.getInstance();
+    private static final String JSON_PROPERTY_NAME_EXCEPTION_MSG = "eMsg";
+
+    public ServerErrorResult() {
+        super(SERVER_ERROR);
+    }
+
+    @Override
+    protected String getDrawTypeString() {
+        return "Server Error";
+    }
+
+    public static class ServerErrorResultJSONConverter extends JSONConverter<ChessMatchResult> {
+
+        private static final ResultType EXPECTED_TYPE = EXCEPTION;
+
+
+        private static ServerErrorResult.ServerErrorResultJSONConverter instance;
+
+        /**
+         * Creates an instance of <code>ExceptionResultJSONConverter</code> to construct a singleton instance
+         */
+        private ServerErrorResultJSONConverter() {
+            super();
+        }
+
+        /**
+         * Gets the instance.
+         *
+         * @return the instance.
+         */
+        public static ServerErrorResult.ServerErrorResultJSONConverter getInstance() {
+            if (instance == null) {
+                instance = new ServerErrorResult.ServerErrorResultJSONConverter();
+            }
+
+            return instance;
+        }
+
+        @Override
+        public ServerErrorResult convertFromJSONObject(@NonNull JSONObject jsonObject) throws JSONException {
+            JSONObject typeJSON = jsonObject.getJSONObject(JSON_PROPERTY_NAME_TYPE);
+            ResultType type = ResultType.JSON_CONVERTER.convertFromJSONObject(typeJSON);
+
+            if (type == EXPECTED_TYPE) {
+                return new ServerErrorResult();
+            } else {
+                throw new JSONException("expected type to be " + EXPECTED_TYPE);
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/jarchess/online/OnlineMatchMaker.java
+++ b/app/src/main/java/com/example/jarchess/online/OnlineMatchMaker.java
@@ -227,9 +227,11 @@ public class OnlineMatchMaker {
             }
         }, "onlineMatchMakerThread");
 
-        t.start();
         synchronized (lock) {
-            Log.i(TAG, "wasCaceled = " + wasCanceled);
+            wasCanceled = false;
+            done = false;
+            onlineMatchInfoBundle = null;
+            t.start();
             while (!done && !wasCanceled) {
                 lock.wait(500);
             }

--- a/app/src/main/java/com/example/jarchess/online/datapackage/DatapackageType.java
+++ b/app/src/main/java/com/example/jarchess/online/datapackage/DatapackageType.java
@@ -5,7 +5,7 @@ import org.json.JSONObject;
 
 public enum DatapackageType implements JSONConvertible<DatapackageType> {
     TURN(0),
-    SERVER_EXCEPTION(1),
+    SERVER_ERROR(1),
     PAUSE_REQUEST(2),
     PAUSE_ACCEPT(3),
     PAUSE_REJECT(4),

--- a/app/src/main/java/com/example/jarchess/online/datapackage/DatapackageType.java
+++ b/app/src/main/java/com/example/jarchess/online/datapackage/DatapackageType.java
@@ -5,7 +5,7 @@ import org.json.JSONObject;
 
 public enum DatapackageType implements JSONConvertible<DatapackageType> {
     TURN(0),
-    RESIGNATION(1),// this is obsolete with match_result
+    SERVER_EXCEPTION(1),
     PAUSE_REQUEST(2),
     PAUSE_ACCEPT(3),
     PAUSE_REJECT(4),


### PR DESCRIPTION
RESIGNATION was an artifact from before the introduction of the ChessMatchResult class. Keeping it around would be redundant and could lead to problems. Instead of removing it and worrying about the index values changing for everything else, I am introducing a new data package type. If the server needs to communicate an error that will terminate the match to the participants, it can send a data package with a type SERVER_ERROR and the client will end the match immediately.